### PR TITLE
Get link destinations via realpath instead of pwd

### DIFF
--- a/functions/marks.fish
+++ b/functions/marks.fish
@@ -17,7 +17,7 @@ function marks
       else
         set -l output ""
         for mark_name in $mark_list
-          set -l real_path (readlink $MARKPATH/$mark_name)
+          set -l real_path (realpath $MARKPATH/$mark_name)
           set output "$output$mark_name -> $real_path"\n
         end
         echo $output | column -t

--- a/functions/marks.fish
+++ b/functions/marks.fish
@@ -15,15 +15,12 @@ function marks
       if test (count $mark_list) -eq 0
         echo "No marks currently defined."
       else
-        set -l current_dir (pwd)
         set -l output ""
         for mark_name in $mark_list
-          cd $MARKPATH/$mark_name
-          set -l real_path (pwd)
+          set -l real_path (readlink $MARKPATH/$mark_name)
           set output "$output$mark_name -> $real_path"\n
         end
         echo $output | column -t
-        cd $current_dir
       end
     end
   end


### PR DESCRIPTION
Using pwd after moving into the link returns the path to the link, not its destination. This PR uses readlink to get the link destination without having to cd into it.

Fixes: #10 