### PR TITLE
Fix issue where `marks` displays symlink path rather than actual path

### DIFF
--- a/functions/marks.fish
+++ b/functions/marks.fish
@@ -18,7 +18,7 @@ function marks
         set -l current_dir (pwd)
         set -l output ""
         for mark_name in $mark_list
-          cd $MARKPATH/$mark_name
+          jump $mark_name
           set -l real_path (pwd)
           set output "$output$mark_name -> $real_path"\n
         end


### PR DESCRIPTION
This fixes the issue where the `marks` command will display the symlink path created by `mark`, rather than the path of the marked directory (see #10 )